### PR TITLE
Set correct yarn command for install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm install raw-loader elm-svg-loader --save-dev
 or
 
 ```
-yarn install raw-loader elm-svg-loader --dev
+yarn add raw-loader elm-svg-loader --dev
 ```
 
 ### Webpack config


### PR DESCRIPTION
The command for adding packages with yarn is not `yarn install` but `yarn add`. :)